### PR TITLE
Change vue router to use history mode

### DIFF
--- a/sashimi-webapp/src/router/index.js
+++ b/sashimi-webapp/src/router/index.js
@@ -6,6 +6,14 @@ import Content from 'components/editor-viewer/Content';
 Vue.use(Router);
 
 export default new Router({
+  mode: 'history',
+  scrollBehavior(to, from, savedPosition) {
+    if (to.hash) {
+      return { selector: to.hash };
+    } else {
+      return { x: 0, y: 0 };
+    }
+  },
   routes: [
     {
       path: '/',


### PR DESCRIPTION
By default vue-router used Hash-mode to switch between pages.  
This behaviour will conflict with our anchor link. #189 

The solution is to use history-mode.
However, we will need to put additional configuration on our server and vue-router to serve the 404 page not found manually. See - https://router.vuejs.org/en/essentials/history-mode.html

Related:
- http://stackoverflow.com/questions/40341939/how-to-create-anchor-tags-with-vue-router
- https://router.vuejs.org/en/advanced/scroll-behavior.html