### PR TITLE
Add additional interaction for editor and viewer

### DIFF
--- a/sashimi-webapp/src/components/editor-viewer/Content.vue
+++ b/sashimi-webapp/src/components/editor-viewer/Content.vue
@@ -31,7 +31,9 @@ export default {
   },
   data() {
     return {
-      mdContent: '',
+      // TODO: Temporary solution for presistence storage
+      //       to be remove when file manager is implemented.
+      mdContent: localStorage.getItem('mdContent'),
       action: '',
       fileFormat: 'html',
       editorCols: {
@@ -79,7 +81,12 @@ export default {
             break;
         }
       }
-    }
+    },
+    mdContent(value) {
+      // TODO: Temporary solution for presistence storage
+      //       to be remove when file manager is implemented.
+      localStorage.setItem('mdContent', value);
+    },
   },
   method: {
   },

--- a/sashimi-webapp/src/components/editor-viewer/Viewer.vue
+++ b/sashimi-webapp/src/components/editor-viewer/Viewer.vue
@@ -59,8 +59,8 @@
     },
     mounted() {
       const PAGE_A6 = {
-        width: '14.8cm',
-        height: '10.5cm',
+        width: '16.51cm',
+        height: '13.159cm',
         padding: {
           top: '1.2cm',
           bottom: '1.2cm',
@@ -148,7 +148,7 @@
     @page {
       size: A4;
       margin: 0;
-    } 
+    }
 
     #app > div > div.section.group.content > div:nth-child(2) {
       width: 100%;

--- a/sashimi-webapp/src/components/editor-viewer/Viewer.vue
+++ b/sashimi-webapp/src/components/editor-viewer/Viewer.vue
@@ -109,6 +109,12 @@
 
     #viewer-container {
       transform: scale(0.75);
+
+      .page-view {
+        overflow: hidden;
+        margin: 0 auto;
+        margin-top: 50px;
+      }
     }
   }
 
@@ -116,12 +122,6 @@
     overflow-wrap: break-word;
     line-height: 1.6em;
     transform-origin: top center;
-
-    .page-view {
-      overflow: hidden;
-      margin: 0 auto;
-      margin-top: 50px;
-    }
   }
   
   #viewer-container,
@@ -141,6 +141,41 @@
     img {
       height: auto;
       width: auto;
+    }
+  }
+
+  @media print {
+    @page {
+      size: A4;
+      margin: 0;
+    } 
+
+    #app > div > div.section.group.content > div:nth-child(2) {
+      width: 100%;
+    }
+
+    .viewer {
+      height: 100%;
+    }
+
+    .navbar, .editor {
+      display: none;
+    }
+
+    .viewer[data-fileFormat="slides"],
+    .viewer[data-fileFormat="pages"] {
+      background: none;
+
+      #viewer-container {
+        transform: scale(1);
+        overflow: hidden;
+
+        .page-view {
+          overflow: hidden;
+          margin: 0;
+          margin-top: 0;
+        }
+      }
     }
   }
 </style>

--- a/sashimi-webapp/src/components/editor-viewer/Viewer.vue
+++ b/sashimi-webapp/src/components/editor-viewer/Viewer.vue
@@ -146,7 +146,7 @@
 
   @media print {
     @page {
-      size: A4;
+      size: auto;
       margin: 0;
     }
 

--- a/sashimi-webapp/src/logic/documentPackager/xssFilter.js
+++ b/sashimi-webapp/src/logic/documentPackager/xssFilter.js
@@ -39,6 +39,7 @@ whiteList.mn = [];
 whiteList.mi = [];
 whiteList.mo = [];
 whiteList.msup = [];
+whiteList.pagebreak = [];
 
 // Custom safeAttrValue function for whiteList
 function safeAttrValue(tag, name, value, cssFilter) {

--- a/sashimi-webapp/src/logic/renderer/VirtualPage.js
+++ b/sashimi-webapp/src/logic/renderer/VirtualPage.js
@@ -12,6 +12,13 @@ export default function VirtualPage(maxHeight) {
   this.filledHeight = 0;
   this.elements = [];
 }
+
+/**
+ * @param {Object} element
+ * @param {Element} element.ele
+ * @param {number} element.height
+ * @return {number} remaining height of the current page
+ */
 VirtualPage.prototype.add = function add(element) {
   if (element.height / this.maxHeight > 1) {
     throw new VirtualPageError('Element is larger than page');


### PR DESCRIPTION
## Persistence storage
@jiayingy @tayjiehao @tharain 
Content added to the editor will be stored inside localStorage for now (3a45841). This is done to simulate the hot-saving feature for the upcoming release. It should be replaced by fileManager in the near future.

## Page break
I have added a special html tag `<pagebreak>` to allow user to manually add page break themselves.
@chuajiaxuan, I will have to add a pagebreak in the xss whitelist (c27d44c).

## Printing
b5063dc 570872b
Proper css layout of printing is available for Page mode now. User can switch to Page Mode and press Ctrl/Cmd print.
Slide mode is also available, however user will have to manually change paper size to "screen" size (16.51cm x 13.159cm).