### PR TITLE
Fix slide and page not getting centralised

### DIFF
--- a/sashimi-webapp/src/logic/inputHandler/DocumentNavigator/EventHandlerManager.js
+++ b/sashimi-webapp/src/logic/inputHandler/DocumentNavigator/EventHandlerManager.js
@@ -97,12 +97,14 @@ export default function(navInstance) {
           navInstance.el.parent.parentNode.scrollTop *= heightChange;
 
           // Readjust left position to fix scroll left problem
-          const parentParent = navInstance.el.parent.parentNode;
-          const pPStyles = domUtils.getComputedStyle(parentParent);
-          const pPWidthPx = unitConverter.get(pPStyles.width, 'px', false);
-          if (renderWidth > pPWidthPx) {
-            const eatenLeft = -(pPWidthPx - renderWidth)/2;
+          const rootNode = navInstance.el.html;
+          const rootStyle = domUtils.getComputedStyle(rootNode);
+          const rootStylePx = unitConverter.get(rootStyle.width, 'px', false);
+          if (renderWidth > rootStylePx) {
+            const eatenLeft = -(rootStylePx - renderWidth)/2;
             navInstance.el.parent.style.left = `${eatenLeft}px`;
+          } else {
+            navInstance.el.parent.style.left = 0;
           }
         }
       },
@@ -135,8 +137,8 @@ export default function(navInstance) {
         const transitionDuration = 500;
         // Resize the element's transformer
         navInstance.el.container.style.transition = `transform ${transitionDuration}ms`;
-        navInstance.width.element = navInstance.width.element || navInstance.width.parent - marginWidth;
-        navInstance.transform.set({ scale: (navInstance.width.parent - marginWidth) / navInstance.width.element });
+        navInstance.width.element = navInstance.width.element || navInstance.width.html - marginWidth;
+        navInstance.transform.set({ scale: (navInstance.width.html - marginWidth) / navInstance.width.element });
         setTimeout(() => {
           navInstance.el.container.style.transition = '';
         }, transitionDuration);

--- a/sashimi-webapp/src/logic/inputHandler/DocumentNavigator/index.js
+++ b/sashimi-webapp/src/logic/inputHandler/DocumentNavigator/index.js
@@ -47,6 +47,7 @@ DocumentNavigator.prototype.updateElementWidth = function updateElementWidth() {
     let elementWidth = domUtils.getComputedStyle(elementReference).width;
 
     // Temporary fix for Firefox computing width as auto
+    elementWidth = elementWidth || '0px';
     elementWidth = (elementWidth === 'auto') ? '0px' : elementWidth;
     this.width[key] = unitConverter.get(elementWidth, 'px', false);
   });

--- a/sashimi-webapp/static/styles/viewer-page.css
+++ b/sashimi-webapp/static/styles/viewer-page.css
@@ -8,6 +8,7 @@ body {
   margin-left: auto;
   margin-right: auto;
   background: #f1f1f1;
+  max-width: initial;
 }
 
 .page-view {


### PR DESCRIPTION
This problem is caused by unwanted `max-width` that messed with the width calculation of page/slide view.