### PR TITLE
Fix a bug caused by markdown-it-asciimath plugin

### DIFF
--- a/sashimi-webapp/src/logic/documentPackager/markdown-it-asciimath.js
+++ b/sashimi-webapp/src/logic/documentPackager/markdown-it-asciimath.js
@@ -49,7 +49,8 @@ function renderInline(str, disp) {
 }
 
 function setup(md, options) {
-  const defaultRender = md.renderer.rules.fence;
+  const defaultFenceRender = md.renderer.rules.fence;
+  const defaultInlineRender = md.renderer.rules.code_inline;
 
   md.renderer.rules.fence = function(tokens, idx, opts, env, self) {
     const token = tokens[idx];
@@ -59,7 +60,7 @@ function setup(md, options) {
     }
 
     // pass token to default renderer.
-    return defaultRender(tokens, idx, opts, env, self);
+    return defaultFenceRender(tokens, idx, opts, env, self);
   };
 
   md.renderer.rules.code_inline = function(tokens, idx, opts, env, self) {
@@ -72,7 +73,7 @@ function setup(md, options) {
       return renderInline(trim(token.content.substr(4)), false);
     }
 
-    return defaultRender(tokens, idx, opts, env, self);
+    return defaultInlineRender(tokens, idx, opts, env, self);
   };
 }
 

--- a/sashimi-webapp/src/logic/documentPackager/markdownProcessor.js
+++ b/sashimi-webapp/src/logic/documentPackager/markdownProcessor.js
@@ -43,8 +43,6 @@ const md = new MarkdownIt({
 // Getting markdown-it to use plugins
 // For KaTeX
 md.use(mdKatex);
-// For ASCIIMath
-md.use(mdAsciiMath);
 // For Code Highlighting
 md.use(mdHighlight, { auto: true, code: true });
 // For TOC generation
@@ -52,6 +50,8 @@ md.use(mdAnchor);
 md.use(mdTOC);
 // For drawing diagrams
 md.use(mdDiagrams);
+// For ASCIIMath
+md.use(mdAsciiMath);
 // For custom conditional plugin
 md.use(mdConditional.hideShowPlugin);
 


### PR DESCRIPTION
Inline codes such as this `a`, gets rendered as code blocks.