### PR TITLE
Fix/iframe style loader run indefinitely

### DIFF
--- a/sashimi-webapp/src/components/editor-viewer/Viewers/Html.vue
+++ b/sashimi-webapp/src/components/editor-viewer/Viewers/Html.vue
@@ -44,6 +44,15 @@
           '/styles/markdown-html.css',
           '/styles/markdown-imports.css'
         ])
+        .catch((error) => {
+          /* eslint no-console: 0 */
+          if (error.message.includes('Error loading style')) {
+            // Disregard loading error and continue to render document.
+            console.error(error.message);
+          } else {
+            throw error;
+          }
+        })
         .then(() => {
           this.renderDoc = this.$el.contentWindow.document;
           renderUpdate(this.renderDoc.body, this.htmlData);

--- a/sashimi-webapp/src/components/editor-viewer/Viewers/Pages.vue
+++ b/sashimi-webapp/src/components/editor-viewer/Viewers/Pages.vue
@@ -42,6 +42,15 @@
           '/styles/viewer-page.css',
           '/styles/markdown-imports.css'
         ])
+        .catch((error) => {
+          /* eslint no-console: 0 */
+          if (error.message.includes('Error loading style')) {
+            // Disregard loading error and continue to render document.
+            console.error(error.message);
+          } else {
+            throw error;
+          }
+        })
         .then(() => {
           const iframeDoc = iframeBuilder.getDocument(this.$el);
 

--- a/sashimi-webapp/src/components/editor-viewer/Viewers/Slides.vue
+++ b/sashimi-webapp/src/components/editor-viewer/Viewers/Slides.vue
@@ -52,6 +52,15 @@
           '/styles/viewer-page.css',
           '/styles/markdown-imports.css'
         ])
+        .catch((error) => {
+          /* eslint no-console: 0 */
+          // Disregard loading error and continue to render document.
+          if (error.message.includes('Error loading style')) {
+            console.error(error.message);
+          } else {
+            throw error;
+          }
+        })
         .then(() => {
           const iframeDoc = iframeBuilder.getDocument(this.$el);
 

--- a/sashimi-webapp/src/helpers/iframeBuilder.js
+++ b/sashimi-webapp/src/helpers/iframeBuilder.js
@@ -43,36 +43,64 @@ export default {
    * @param {Element} iframeElement
    * @param {string} url string pointing to a stylesSheet
    * @return {Promise} return a promise when all the styles has been loaded
+   * @throws {Error} "Error loading style link..." if link failed to load or is empty.
    */
-  addStyle(iframeElement, style) {
+  addStyle(iframeElement, styleUrl) {
     return new Promise((resolve, reject) => {
-      const styleElement = constructStyleLink(iframeElement.contentWindow.document, style);
-      this.getDocument(iframeElement).head.appendChild(styleElement);
+      const styleElement = constructStyleLink(iframeElement.contentWindow.document, styleUrl);
 
       // Resolve only when the style has been loaded.
+      // Monitoring is done before stylesheet got inserted.
       // https://www.phpied.com/when-is-a-stylesheet-really-loaded/
-      // This doesn't work well with Firefox and IE. This will result in
-      //   the initial rendering of css to not work correctly.
-      //   However, subsequent rendering should work normally.
-      // Temporary solution:
-      //   All CSS will get loaded in 10ms, a polling of 50ms setInterval
-      //   is sufficient to ensure all css get loaded and rendered.
-      // TODO: Implement a better solution for this problem
-      const poller = setInterval(() => {
-        const styleSheets = iframeElement.contentWindow.document.styleSheets;
-
-        for (let i = 0; i < styleSheets.length; i += 1) {
-          const stylesheet = styleSheets[i];
-
-          // A trival way to check if the intended css has been loaded.
-          // This method check for substring only, so stylesheet with similar
-          //   name will not work.
-          if (stylesheet.href.includes(style)) {
-            resolve();
+      if (styleElement.onload === null) { // onload is defined but not set
+        // Solution for most modern browser.
+        // 'onload' will be emitted by all major browser,
+        //   IE/Edge, Webkit and Chrome > 2012, Firefox > 2014.
+        styleElement.onload = () => {
+          resolve();
+        };
+        styleElement.onerror = (event) => {
+          reject(new Error(`Error loading style link: ${event.target.href}`));
+        };
+      } else {
+        // Fall back solution for older browser before 2014
+        // This solution only for for Chrome, Safari and Webkit browser
+        const pollIncrement = 50;
+        const poller = setInterval(() => {
+          // If the iframe window doesn't exist, loading of style should be terminated.
+          //   Since the content no longer exist. There is no need to load the style anymore.
+          //   Therefore, no error should be thrown.
+          if (!iframeElement.contentWindow) {
             clearInterval(poller);
+            return;
           }
-        }
-      }, 50);
+
+          const styleSheets = iframeElement.contentWindow.document.styleSheets;
+          for (let i = 0; i < styleSheets.length; i += 1) {
+            const stylesheet = styleSheets[i];
+
+            // A trival way to check if the intended css has been loaded.
+            // This method check for substring only, so stylesheet with similar
+            //   name will not work.
+            const hasParsedStyleSheet = stylesheet.href.includes(styleUrl);
+
+            if (hasParsedStyleSheet) {
+              clearInterval(poller);
+              const styleRules = stylesheet.rule || stylesheet.cssRules;
+              if (styleRules.length > 0) {
+                resolve();
+              } else {
+                // CSS style is either empty or failed to load.
+                reject(`Error loading style link: ${stylesheet.href}`);
+              }
+              return;
+            }
+          }
+        }, pollIncrement);
+      }
+
+      // Insert style link into stylesheet
+      this.getDocument(iframeElement).head.appendChild(styleElement);
     });
   },
 
@@ -81,10 +109,11 @@ export default {
    * @param {Element} iframeElement
    * @param {Array<string>} An array of url string pointing to a stylesSheet
    * @return {Promise} return a promise when all the styles has been loaded
+   * @throws {Error} "Error loading style link..." if link failed to load or is empty.
    */
-  addStyles(iframeElement, styles) {
-    return Promise.all(styles.map(style =>
-      this.addStyle(iframeElement, style)
+  addStyles(iframeElement, stylesUrl) {
+    return Promise.all(stylesUrl.map(styleUrl =>
+      this.addStyle(iframeElement, styleUrl)
     ));
   },
 };


### PR DESCRIPTION
To fix issue #366

- Stylesheet loading check will now use `.onload` function. All modern browser will emit a load event when the style is done parsing.
    - IE/Edge has support since IE9
    - Chrome and Webkit started supporting ~ 2012
    - Firefox started supporting ~ 2014
    - Other: https://pie.gd/test/script-link-events/
- If the onload function is undefined, it will fallback to use the old polling method.
- Stylesheeting loading error will be ignore. This is to prevent document not getting rendered after a CSS loading failure (Because I am considering this as a non-critical failure).