### PR TITLE
Remove asciimath plugin in from development/v0.1.4

### DIFF
--- a/sashimi-webapp/package.json
+++ b/sashimi-webapp/package.json
@@ -71,7 +71,6 @@
     "lolex": "^1.5.2",
     "markdown-it": "^8.2.2",
     "markdown-it-anchor": "^3.0.0",
-    "markdown-it-asciimath": "^0.1.0",
     "markdown-it-highlightjs": "^2.0.0",
     "markdown-it-katex": "^2.0.3",
     "markdown-it-table-of-contents": "^0.3.2",

--- a/sashimi-webapp/yarn.lock
+++ b/sashimi-webapp/yarn.lock
@@ -3909,12 +3909,6 @@ markdown-it-anchor@^3.0.0:
   dependencies:
     string "^3.0.1"
 
-markdown-it-asciimath@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-asciimath/-/markdown-it-asciimath-0.1.0.tgz#33ef4f8818762075e1920b771a3c6bc60d43fa5b"
-  dependencies:
-    katex "^0.6.0"
-
 markdown-it-highlightjs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-highlightjs/-/markdown-it-highlightjs-2.0.0.tgz#f9b55723d037ec1e71bc66e3499d4f7487018b26"


### PR DESCRIPTION
Since we are using customised files of the asciimath plugin we don't need it anymore.