### PR TITLE
Fix unresolvable xlxs dependency from alasql

### DIFF
--- a/sashimi-webapp/package.json
+++ b/sashimi-webapp/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "alasql": "^0.3.7",
+    "alasql": "^0.4.1",
     "autoprefixer": "^6.7.2",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",

--- a/sashimi-webapp/yarn.lock
+++ b/sashimi-webapp/yarn.lock
@@ -37,7 +37,7 @@ acorn@^4.0.11, acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
-adler-32@:
+adler-32@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.0.0.tgz#28728a71756f629666dd1653cd80793a9df18651"
   dependencies:
@@ -71,16 +71,15 @@ ajv@^4.11.2, ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-alasql@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/alasql/-/alasql-0.3.7.tgz#c6e5ef8f9365c308cb36bfc53fde6996280c8d6e"
+alasql@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/alasql/-/alasql-0.4.1.tgz#5328bc33fc4698a2a00777139083dce464919a1c"
   dependencies:
     dom-storage "^2.0.1"
     es6-promise "^4.0.5"
     lodash "^4.17.4"
     request "^2.79.0"
-    xlsjs "^0.7.5"
-    xlsx "^0.8.4"
+    xlsx "^0.9.13"
     yargs "^5.0.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
@@ -1145,9 +1144,9 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-cfb@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/cfb/-/cfb-0.11.0.tgz#3ab793e72ebaf16a4b8704133b6bed5a355ea6e2"
+cfb@~0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/cfb/-/cfb-0.11.1.tgz#a96db8f272a6c3fb99dbbb23ef41223f48be1ea7"
   dependencies:
     commander ""
 
@@ -1284,9 +1283,9 @@ codemirror@^5.19.0, codemirror@^5.25.0:
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.25.0.tgz#78e06939c7bb41f65707b8aa9c5328111948b756"
 
-codepage@:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.6.0.tgz#2c7e630859c36ccfcb4d392d70781ab745945a1f"
+codepage@~1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.8.1.tgz#f1a009d5261dc2754628bacb6fbbf0e6e2abffaa"
   dependencies:
     commander ""
     concat-stream ""
@@ -1345,7 +1344,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@, commander@2.9.0, commander@2.9.x, commander@^2.5.0, commander@^2.9.0:
+commander@, commander@2.9.0, commander@2.9.x, commander@^2.5.0, commander@^2.9.0, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1485,11 +1484,10 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-crc-32@:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.0.1.tgz#2efbddb7ccbb7beb4d181803b10e33a29c9fd214"
+crc-32@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.0.2.tgz#09507984ee9bcce3bd1b8861f0de8ab10ae8187d"
   dependencies:
-    concat-stream ""
     exit-on-epipe ""
     printj ""
 
@@ -2358,6 +2356,10 @@ exit-on-epipe@:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.0.tgz#f6e0579c8214d33a08109fd6e2e5c1dbc70463fc"
 
+exit-on-epipe@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+
 expand-braces@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/expand-braces/-/expand-braces-0.1.2.tgz#488b1d1d2451cb3d3a6b192cfc030f44c5855fea"
@@ -2590,9 +2592,11 @@ forwarded@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
 
-frac@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/frac/-/frac-0.3.1.tgz#577677b7fdcbe6faf7c461f1801d34137cda4354"
+frac@~1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/frac/-/frac-1.0.6.tgz#9a0dfc23956852a8b320623bebcf1be9ea048229"
+  dependencies:
+    voc ""
 
 fresh@0.3.0:
   version "0.3.0"
@@ -5694,12 +5698,12 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-ssf@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.8.2.tgz#b9d4dc6a1c1bcf76f8abfa96d7d7656fb2abecd6"
+ssf@~0.9.1:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.9.4.tgz#8e57a98c19dbbf1edd53f0f8c9e7fd524b0f6c9c"
   dependencies:
     colors "0.6.2"
-    frac "0.3.1"
+    frac "~1.0.6"
     voc ""
 
 sshpk@^1.7.0:
@@ -6392,27 +6396,17 @@ wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
 
-xlsjs@^0.7.5:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/xlsjs/-/xlsjs-0.7.6.tgz#d88754569aabcf8eea70cc23961b462634a49565"
+xlsx@^0.9.13:
+  version "0.9.13"
+  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.9.13.tgz#5861d11e10a1f99b6f2b491e2d119a7777d066e7"
   dependencies:
-    cfb "~0.11.0"
-    codepage ""
-    commander ""
-    exit-on-epipe ""
-    ssf "~0.8.1"
-
-xlsx@^0.8.4:
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.8.6.tgz#52ed85745495835f5625e438e8377498b9d2e7e7"
-  dependencies:
-    adler-32 ""
-    cfb "~0.11.0"
-    codepage ""
-    commander ""
-    crc-32 ""
-    exit-on-epipe ""
-    ssf "~0.8.1"
+    adler-32 "~1.0.0"
+    cfb "~0.11.1"
+    codepage "~1.8.0"
+    commander "~2.9.0"
+    crc-32 "~1.0.2"
+    exit-on-epipe "~1.0.0"
+    ssf "~0.9.1"
 
 xml-char-classes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
```
Trace: 
  Error: https://registry.yarnpkg.com/xlsx/-/xlsx-0.8.6.tgz: Request failed "404 Not Found"
      at Request.handleRequestError (C:\Program Files (x86)\Yarn\lib\yarn-cli.js:56351:20)
      at emitOne (events.js:96:13)
      at Request.emit (events.js:188:7)
      at Request.onRequestResponse (C:\Program Files (x86)\Yarn\lib\yarn-cli.js:115128:10)
      at emitOne (events.js:96:13)
      at ClientRequest.emit (events.js:188:7)
      at HTTPParser.parserOnIncomingClient (_http_client.js:474:21)
      at HTTPParser.parserOnHeadersComplete (_http_common.js:99:23)
      at TLSSocket.socketOnData (_http_client.js:363:20)
      at emitOne (events.js:96:13)
      at TLSSocket.emit (events.js:188:7)
```